### PR TITLE
Add zero padding to the timer

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,4 +1,4 @@
 import { expect, test } from 'vitest';
 import { formatTime } from './utils';
 
-test('formats 1001 to "0:1"', () => expect(formatTime(1001)).toBe('0:1'));
+test('formats 1001 to "0:1"', () => expect(formatTime(1001)).toBe('00:01'));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,10 @@
+function zeroPad(n: number) {
+	return n >= 10 ? n.toString() : `0${n}`;
+}
+
 export function formatTime(milliseconds: number) {
-	const ss = Math.floor(milliseconds / 1000) % 60;
-	const mm = Math.floor(milliseconds / 1000 / 60);
+	const ss = zeroPad(Math.floor(milliseconds / 1000) % 60);
+	const mm = zeroPad(Math.floor(milliseconds / 1000 / 60));
 
 	return `${mm}:${ss}`;
 }


### PR DESCRIPTION
Examples:
* "0:0"  => "00:00"
* "0:5"  => "00:05"
* "0:11" => "00:11"
* "10:2" => "10:02
