### PR TITLE
flip true default for game view

### DIFF
--- a/src/routes/tournaments/[tournamentId]/games/[gameId]/+page.svelte
+++ b/src/routes/tournaments/[tournamentId]/games/[gameId]/+page.svelte
@@ -77,7 +77,7 @@
 		</div>
 	</div>
 
-	<EventsWindow {game} class="h-80 w-80 overflow-auto" />
+	<EventsWindow {game} flip={true} class="h-80 w-80 overflow-auto" />
 </main>
 
 <style>


### PR DESCRIPTION
The scores were flipped for the game view page.

The flip button is automatically on, while the game-view page assumes home team not flipped.

Manually flip the scores for the game view page to flip them back.

Fastest way to fix the issue.

**Before**
<img width="2506" height="1238" alt="image" src="https://github.com/user-attachments/assets/1cd804db-1277-40a2-be76-56936a89bf37" />

**After**
<img width="2479" height="1214" alt="image" src="https://github.com/user-attachments/assets/79ecd516-4438-489c-85f0-7b7d184d81aa" />

